### PR TITLE
Also redact tokens and secrets

### DIFF
--- a/resource/status/resource.js
+++ b/resource/status/resource.js
@@ -26,7 +26,7 @@ module.exports = function( host, config, status ) {
 				method: "get",
 				handle: function() {
 					return _.reduce( process.env, function( acc, value, key ) {
-						if ( !/pass/ig.test( key ) ) {
+						if ( !/(pass|token|secret)/ig.test( key ) ) {
 							acc[ key ] = value;
 						} else {
 							acc[ key ] = "redacted";

--- a/spec/.jshintrc
+++ b/spec/.jshintrc
@@ -9,7 +9,7 @@
 	// levels.
 
 	"bitwise"   : true,   //prohibits the use of bitwise operators such as ^ (XOR), | (OR) and others
-	"camelcase" : true,   //force all variable names to use either camelCase style or UPPER_CASE with underscores
+	"camelcase" : false,   //force all variable names to use either camelCase style or UPPER_CASE with underscores
 	"curly"     : true,   //requires you to always put curly braces around blocks in loops and conditionals
 	"eqeqeq"    : true,   //prohibits the use of == and != in favor of === and !==
 	"forin"     : true,   //requires all `for in` loops to filter object's items with `hasOwnProperty()`

--- a/spec/behavior/status.resource.spec.js
+++ b/spec/behavior/status.resource.spec.js
@@ -1,0 +1,49 @@
+require( "../setup" );
+
+var sampleEnv = {
+	PASSWORD: "secret",
+	user_pass: "secret",
+	OTHER_SECRET: "secret",
+	secret_word: "secret",
+	APITOKEN: "secret",
+	my_token: "secret",
+	normal: "not secret"
+};
+
+describe( "Status Resource", function() {
+	var statusResourceFactory = require( "../../resource/status/resource.js" );
+	describe( "environment", function() {
+		var result;
+		before( function() {
+			_.extend( process.env, sampleEnv );
+
+			var resource = statusResourceFactory();
+			result = resource.actions.environment.handle();
+		} );
+
+		it( "should redact anything containing \"pass\" regardless of case", function() {
+			result.PASSWORD.should.equal( "redacted" );
+			result.user_pass.should.equal( "redacted" );
+		} );
+
+		it( "should redact anything containing \"secret\" regardless of case", function() {
+			result.OTHER_SECRET.should.equal( "redacted" );
+			result.secret_word.should.equal( "redacted" );
+		} );
+
+		it( "should redact anything containing \"token\" regardless of case", function() {
+			result.APITOKEN.should.equal( "redacted" );
+			result.my_token.should.equal( "redacted" );
+		} );
+
+		it( "should return all other variables un-redacted", function() {
+			result.normal.should.equal( "not secret" );
+		} );
+
+		after( function() {
+			Object.keys( sampleEnv ).forEach( function( k ) {
+				delete process.env[ k ];
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
This will attempt to redact anything with `token` or `secret` in the env variable name. Also added tests. There were 2 existing tests that weren't passing that were unrelated to my changes (Something about an extra `_status` that wasn't expected).
